### PR TITLE
copying metadata.n3 into each robot type directory

### DIFF
--- a/clean-install.sh
+++ b/clean-install.sh
@@ -33,7 +33,7 @@ setup_robot() {
 
 	log_exec ln -sf "../ur-serial.$robot_type" "$robot_type/ur-serial"
 
-  cp "metadata.n3" "$robot_type"
+  log_exec ln -sf "../metadata.n3" "$robot_type/metadata.n3"
 }
 
 extract_deb() {

--- a/clean-install.sh
+++ b/clean-install.sh
@@ -32,6 +32,8 @@ setup_robot() {
 	done
 
 	log_exec ln -sf "../ur-serial.$robot_type" "$robot_type/ur-serial"
+
+  cp "metadata.n3" "$robot_type"
 }
 
 extract_deb() {


### PR DESCRIPTION
Fixes an issue where the Polyscope version cant be found.

This issue results in some layout parameters defaulting to the e-series values, which causes scaling issues on the cb-series.

Less importantly it results in a missing version number in the about section.

Probably fixes other problems as well, deriving from defaulting to e-series.