### PR TITLE
added missing startup parameter for URControl, resultinig in error: "…

### DIFF
--- a/controller.sh
+++ b/controller.sh
@@ -23,7 +23,7 @@ function on_sigint {
 trap on_sigint SIGINT
 
 #Start the controller
-HOME="$URSIM_ROOT" ../URControl &
+HOME="$URSIM_ROOT" ../URControl -r &
 controller_pid=$!
 sleep 1
 


### PR DESCRIPTION
…Failed to start URbus", on e-series

This solves issue #4 .

Im not gonna speculate what this parameter does, but UR includes it in their own startup script (atleast on the newest version) and it works for both cb-series and e-series.

UR did however forget this parameter (or forgot to update it) in their install instructions on the download page:

![enableModbus](https://user-images.githubusercontent.com/34939148/100200039-5c4c3080-2efe-11eb-9061-4ac8ef158118.png)
